### PR TITLE
Actually publish orb updates to Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,10 @@ workflows:
               only:
                 - /^v\d+\.\d+\.\d+$/
       - orb-tools/publish:
+          filters:
+            tags:
+              only:
+                - /^v\d+\.\d+\.\d+$/
           requires:
             - orb-tools/pack
           orb-ref: rainforest-qa/rainforest@${CIRCLE_TAG:1}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Rainforest QA CircleCI Orb
-**Registry homepage:** [`rainforest-qa/rainforest@0.2.0`](https://circleci.com/orbs/registry/orb/rainforest-qa/rainforest)
+**Registry homepage:** [`rainforest-qa/rainforest@0.2.1`](https://circleci.com/orbs/registry/orb/rainforest-qa/rainforest)
 
 > This is the Rainforest QA [Orb](https://circleci.com/docs/2.0/orb-intro/) for CircleCI, it allows you to easily kick off a Rainforest run from your CircleCI workflows, to make sure that every release passes your Rainforest integration tests.
 
@@ -39,7 +39,7 @@ version: 2.1
 # If you don't have a top-level `orbs` section, add one
 orbs:
 # Add the Rainforest orb to that list
-  - rainforest: rainforest-qa/rainforest@0.2.0
+  - rainforest: rainforest-qa/rainforest@0.2.1
 
 # In your workflows, add it as a job to be run
 workflows:

--- a/src/examples/simple.yml
+++ b/src/examples/simple.yml
@@ -3,7 +3,7 @@ description: Run tests from a specific run group
 usage:
   version: 2.1
   orbs:
-    rainforest: rainforest-qa/rainforest@0.2.0
+    rainforest: rainforest-qa/rainforest@0.2.1
   workflows:
     build:
       jobs:


### PR DESCRIPTION
🤦‍♂️

Circle builds don't run on tags by default, so that filter needs to be added to all jobs in the `release` workflow (no workflow-level filters).