### PR TITLE
Properly fix releasing to Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,5 +36,6 @@ workflows:
                 - /^v\d+\.\d+\.\d+$/
           requires:
             - orb-tools/pack
+          attach-workspace: true
           orb-ref: rainforest-qa/rainforest@${CIRCLE_TAG:1}
           publish-token-variable: CIRCLE_ORG_ADMIN_TOKEN

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Rainforest QA CircleCI Orb
-**Registry homepage:** [`rainforest-qa/rainforest@0.2.1`](https://circleci.com/orbs/registry/orb/rainforest-qa/rainforest)
+**Registry homepage:** [`rainforest-qa/rainforest@0.2.2`](https://circleci.com/orbs/registry/orb/rainforest-qa/rainforest)
 
 > This is the Rainforest QA [Orb](https://circleci.com/docs/2.0/orb-intro/) for CircleCI, it allows you to easily kick off a Rainforest run from your CircleCI workflows, to make sure that every release passes your Rainforest integration tests.
 
@@ -39,7 +39,7 @@ version: 2.1
 # If you don't have a top-level `orbs` section, add one
 orbs:
 # Add the Rainforest orb to that list
-  - rainforest: rainforest-qa/rainforest@0.2.1
+  - rainforest: rainforest-qa/rainforest@0.2.2
 
 # In your workflows, add it as a job to be run
 workflows:

--- a/src/examples/simple.yml
+++ b/src/examples/simple.yml
@@ -3,7 +3,7 @@ description: Run tests from a specific run group
 usage:
   version: 2.1
   orbs:
-    rainforest: rainforest-qa/rainforest@0.2.1
+    rainforest: rainforest-qa/rainforest@0.2.2
   workflows:
     build:
       jobs:


### PR DESCRIPTION
The workspace is attached by default in orb-tools/publish-dev, but not orb-tools/publish...