### PR TITLE
Revert "Fix extra backslashes for ungiven parameters"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Rainforest QA CircleCI Orb
-**Registry homepage:** [`rainforest-qa/rainforest@0.2.3`](https://circleci.com/orbs/registry/orb/rainforest-qa/rainforest)
+**Registry homepage:** [`rainforest-qa/rainforest@0.2.4`](https://circleci.com/orbs/registry/orb/rainforest-qa/rainforest)
 
 > This is the Rainforest QA [Orb](https://circleci.com/docs/2.0/orb-intro/) for CircleCI, it allows you to easily kick off a Rainforest run from your CircleCI workflows, to make sure that every release passes your Rainforest integration tests.
 
@@ -39,7 +39,7 @@ version: 2.1
 # If you don't have a top-level `orbs` section, add one
 orbs:
 # Add the Rainforest orb to that list
-  - rainforest: rainforest-qa/rainforest@0.2.3
+  - rainforest: rainforest-qa/rainforest@0.2.4
 
 # In your workflows, add it as a job to be run
 workflows:

--- a/src/commands/run_qa.yml
+++ b/src/commands/run_qa.yml
@@ -80,7 +80,7 @@ steps:
           --token "${<< parameters.token >>}" \
           --description "<< parameters.description >>" \
           --run-group "<< parameters.run_group_id >>" \
-          <<# parameters.environment_id >> --environment-id "<< parameters.environment_id >>" \ <</ parameters.environment_id >>
-          <<# parameters.conflict >> --conflict "<< parameters.conflict >>" \ <</ parameters.conflict >>
-          <<# parameters.crowd >> --crowd "<< parameters.crowd >>" \ <</ parameters.crowd >>
+          <<# parameters.environment_id >> --environment-id "<< parameters.environment_id >>" <</ parameters.environment_id >> \
+          <<# parameters.conflict >> --conflict "<< parameters.conflict >>" <</ parameters.conflict >> \
+          <<# parameters.crowd >> --crowd "<< parameters.crowd >>" <</ parameters.crowd >> \
           --release "<< parameters.release >>"

--- a/src/examples/simple.yml
+++ b/src/examples/simple.yml
@@ -3,7 +3,7 @@ description: Run tests from a specific run group
 usage:
   version: 2.1
   orbs:
-    rainforest: rainforest-qa/rainforest@0.2.3
+    rainforest: rainforest-qa/rainforest@0.2.4
   workflows:
     build:
       jobs:


### PR DESCRIPTION
This reverts commit `2c956f3ff9e87566ae72d96a1a8ab42ba7c9c7ef`.

Turns out those were necessary.