### PR TITLE
Skip CLI update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Rainforest QA CircleCI Orb
-**Registry homepage:** [`rainforest-qa/rainforest@1.0.0`](https://circleci.com/orbs/registry/orb/rainforest-qa/rainforest)
+**Registry homepage:** [`rainforest-qa/rainforest@1.0.1`](https://circleci.com/orbs/registry/orb/rainforest-qa/rainforest)
 
 > This is the Rainforest QA [Orb](https://circleci.com/docs/2.0/orb-intro/) for CircleCI, it allows you to easily kick off a Rainforest run from your CircleCI workflows, to make sure that every release passes your Rainforest integration tests.
 
@@ -39,7 +39,7 @@ version: 2.1
 # If you don't have a top-level `orbs` section, add one
 orbs:
 # Add the Rainforest orb to that list
-  - rainforest: rainforest-qa/rainforest@1.0.0
+  - rainforest: rainforest-qa/rainforest@1.0.1
 
 # In your workflows, add it as a job to be run
 workflows:

--- a/src/commands/run_qa.yml
+++ b/src/commands/run_qa.yml
@@ -83,6 +83,7 @@ steps:
         if ! << parameters.dry_run >> ; then
           # Create the run
           rainforest-cli run \
+            --skip-update \
             --token "${<< parameters.token >>}" \
             --description "<< parameters.description >>" \
             --run-group "<< parameters.run_group_id >>" \

--- a/src/examples/simple.yml
+++ b/src/examples/simple.yml
@@ -3,7 +3,7 @@ description: Run tests from a specific run group
 usage:
   version: 2.1
   orbs:
-    rainforest: rainforest-qa/rainforest@1.0.0
+    rainforest: rainforest-qa/rainforest@1.0.1
   workflows:
     build:
       jobs:


### PR DESCRIPTION
> We should add the `--skip-update` flag because:
> * we're already specifying to use the latest image as an executor, so this check is redundant, and having it makes the deploy less reliable as it adds a dependency on the updating service
> * not including the argument means that if we did specify a particular version of CLI in the orb, it wouldn't be honoured and we'd probably not notice, leading to bugs