### PR TITLE
RF-17119 Rename rainforest executable in the install command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       - run:
           name: Is the CLI present, is it from the stable channel
           command: |
-            /usr/local/bin/rainforest --skip-update --version | tee /tmp/rf-version
+            /usr/local/bin/rainforest-cli --skip-update --version | tee /tmp/rf-version
             grep 'stable channel' /tmp/rf-version
 
 workflows:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Rainforest QA CircleCI Orb
-**Registry homepage:** [`rainforest-qa/rainforest@1.1.0`](https://circleci.com/orbs/registry/orb/rainforest-qa/rainforest)
+**Registry homepage:** [`rainforest-qa/rainforest@1.2.0`](https://circleci.com/orbs/registry/orb/rainforest-qa/rainforest)
 
 > This is the Rainforest QA [Orb](https://circleci.com/docs/2.0/orb-intro/) for CircleCI, it allows you to easily kick off a Rainforest run from your CircleCI workflows, to make sure that every release passes your Rainforest integration tests.
 
@@ -40,7 +40,7 @@ version: 2.1
 # If you don't have a top-level `orbs` section, add one
 orbs:
 # Add the Rainforest orb to that list
-  - rainforest: rainforest-qa/rainforest@1.1.0
+  - rainforest: rainforest-qa/rainforest@1.2.0
 
 # In your workflows, add it as a job to be run
 workflows:

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -37,3 +37,4 @@ steps:
 
         wget $url
         tar xvf $file -C << parameters.install_path >>
+        mv << parameters.install_path >>/rainforest << parameters.install_path >>/rainforest-cli

--- a/src/examples/simple.yml
+++ b/src/examples/simple.yml
@@ -3,7 +3,7 @@ description: Run tests from a specific run group
 usage:
   version: 2.1
   orbs:
-    rainforest: rainforest-qa/rainforest@1.1.0
+    rainforest: rainforest-qa/rainforest@1.2.0
   workflows:
     build:
       jobs:


### PR DESCRIPTION
The "install" command installs the RF cli to a file called "rainforest"
but the "run_qa" command executes "rainforest-cli" because that's the
name of the docker image.

Rename the CLI in the "install" command so it's usable by the "run"
command.