### PR TITLE
Documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 * [Commands](##Commands)
 * [Executors](##Executors)
 * [Examples](##Examples)
-* [Orb Release Process](##Orb Release Process)
+* [Orb Release Process](##Orb%20Release%20Process)
 
 ## Prerequisites
 

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -5,5 +5,5 @@ description: |
   Prerequisites:
     - a Rainforest QA account (https://app.rainforestqa.com/trial)
     - a Rainforest QA API token (https://app.rainforestqa.com/settings/integrations)
-    - a RunGroup with some tests (https://app.rainforestqa.com/tests)
+    - a RunGroup with some tests (https://app.rainforestqa.com/run_groups)
   Orb repo (fleshed out README and full source code): https://github.com/rainforestapp/rainforest-orb


### PR DESCRIPTION
Fixes a header link in the README, and points to the new `/run_groups` view in the orb documentation hosted on Circle.