### PR TITLE
RF-17248 Various changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
     executor: rf/default
     environment:
       TOP_SECRET_TOKEN: 'MY_SECRET_PASSWORD'
+      TOP_SECRET_TOKEN_WITH_SPACES: 'MY SECRET PASSWORD'
     steps:
       - rf/install:
           architecture: "386"
@@ -28,6 +29,10 @@ jobs:
       - rf/run_qa:
           dry_run: true
           token: 'TOP_SECRET_TOKEN'
+          run_group_id: '123'
+      - rf/run_qa:
+          dry_run: true
+          token: 'TOP_SECRET_TOKEN_WITH_SPACES'
           run_group_id: '123'
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,8 @@ parameters:
 jobs:
   integration-tests-for-your-orb:
     executor: rf/default
+    environment:
+      TOP_SECRET_TOKEN: 'MY_SECRET_PASSWORD'
     steps:
       - rf/install:
           architecture: "386"
@@ -23,6 +25,10 @@ jobs:
           command: |
             /usr/local/bin/rainforest-cli --skip-update --version | tee /tmp/rf-version
             grep 'stable channel' /tmp/rf-version
+      - rf/run_qa:
+          dry_run: true
+          token: 'TOP_SECRET_TOKEN'
+          run_group_id: '123'
 
 workflows:
   integration-tests_prod-release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,23 @@ jobs:
           dry_run: true
           token: 'TOP_SECRET_TOKEN_WITH_SPACES'
           run_group_id: '123'
+      - rf/run_qa:
+          dry_run: true
+          token: 'TOP_SECRET_TOKEN'
+          run_group_id: '123'
+          environment_id: '1234'
+      - rf/run_qa:
+          dry_run: true
+          token: 'TOP_SECRET_TOKEN'
+          run_group_id: '123'
+          environment_id: '1234'
+          conflict: abort
+      - rf/run_qa:
+          dry_run: true
+          token: 'TOP_SECRET_TOKEN'
+          run_group_id: '123'
+          environment_id: '1234'
+          conflict: abort-all
 
 workflows:
   integration-tests_prod-release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,25 +27,30 @@ jobs:
             /usr/local/bin/rainforest-cli --skip-update --version | tee /tmp/rf-version
             grep 'stable channel' /tmp/rf-version
       - rf/run_qa:
+        # Check run group validation
           dry_run: true
           token: 'TOP_SECRET_TOKEN'
           run_group_id: '123'
       - rf/run_qa:
+        # Validate tokens with spaces in without blowing up
           dry_run: true
           token: 'TOP_SECRET_TOKEN_WITH_SPACES'
           run_group_id: '123'
       - rf/run_qa:
+        # Check environment_id is validated
           dry_run: true
           token: 'TOP_SECRET_TOKEN'
           run_group_id: '123'
           environment_id: '1234'
       - rf/run_qa:
+        # Check conflict with abort is validated
           dry_run: true
           token: 'TOP_SECRET_TOKEN'
           run_group_id: '123'
           environment_id: '1234'
           conflict: abort
       - rf/run_qa:
+        # Check conflict with abort-all is validated
           dry_run: true
           token: 'TOP_SECRET_TOKEN'
           run_group_id: '123'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# Rainforest QA CircleCI Orb
-**Registry homepage:** [`rainforest-qa/rainforest@1.2.0`](https://circleci.com/orbs/registry/orb/rainforest-qa/rainforest)
+# Rainforest QA CircleCI Orb ![](https://img.shields.io/github/v/release/rainforestapp/rainforest-orb.svg)
+
+**Registry homepage:** [`rainforest-qa/rainforest`](https://circleci.com/orbs/registry/orb/rainforest-qa/rainforest)
 
 > This is the Rainforest QA [Orb](https://circleci.com/docs/2.0/orb-intro/) for CircleCI, it allows you to easily kick off a Rainforest run from your CircleCI workflows, to make sure that every release passes your Rainforest integration tests.
 

--- a/src/commands/run_qa.yml
+++ b/src/commands/run_qa.yml
@@ -45,7 +45,7 @@ steps:
       name: Run Rainforest
       command: |
         # Validate token
-        if ! [ ${<< parameters.token >>} ] ; then
+        if [ -z "${<< parameters.token >>}" ] ; then
           echo "Error: Token not set"
           exit 1
         fi

--- a/src/commands/run_qa.yml
+++ b/src/commands/run_qa.yml
@@ -51,14 +51,14 @@ steps:
         fi
 
         # Validate run_group_id
-        if ! echo "<< parameters.run_group_id >>" | grep -Eq '^\d+$' ; then
+        if ! echo "<< parameters.run_group_id >>" | grep -Eq '^[0-9]+$' ; then
           echo "Error: run_group_id not a positive integer (<< parameters.run_group_id >>)"
           exit 1
         fi
 
         # Validate environment_id
         if [ -n "<< parameters.environment_id >>" ] ; then
-          if ! echo "<< parameters.environment_id >>" | grep -Eq '^\d+$' ; then
+          if ! echo "<< parameters.environment_id >>" | grep -Eq '^[0-9]+$' ; then
             echo "Error: environment_id not a positive integer (<< parameters.environment_id >>)"
             exit 1
           fi


### PR DESCRIPTION
* Change the README so it has a badge showing the current release - this means we have one less place to update the version when we update it
* Add tests for the `run_qa` command parameters
* Change the numeric validations for `run_qa` to not use the `\d` regex shortcut - which doesn't work when `POSIXLY_CORRECT` is set
* Allow the token to have spaces in it