### PR TITLE
Add Home URL and Source Code URL

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -6,4 +6,7 @@ description: |
     - a Rainforest QA account (https://app.rainforestqa.com/trial)
     - a Rainforest QA API token (https://app.rainforestqa.com/settings/integrations)
     - a RunGroup with some tests (https://app.rainforestqa.com/run_groups)
-  Orb repo (fleshed out README and full source code): https://github.com/rainforestapp/rainforest-orb
+
+display:
+  home_url: https://rainforestqa.com
+  source_url: https://github.com/rainforestapp/rainforest-orb


### PR DESCRIPTION
Display a link to your home page and the orb source natively in the Orb registry as a clickable link.