### PR TITLE
[RF-18027] Rerun failed Rainforest tests when rerunning failed Circle build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,17 +31,20 @@ jobs:
           dry_run: true
           token: 'TOP_SECRET_TOKEN'
           run_group_id: '123'
+          pipeline_id: << pipeline.id >>
       - rf/run_qa:
         # Validate tokens with spaces in without blowing up
           dry_run: true
           token: 'TOP_SECRET_TOKEN_WITH_SPACES'
           run_group_id: '123'
+          pipeline_id: << pipeline.id >>
       - rf/run_qa:
         # Check environment_id is validated
           dry_run: true
           token: 'TOP_SECRET_TOKEN'
           run_group_id: '123'
           environment_id: '1234'
+          pipeline_id: << pipeline.id >>
       - rf/run_qa:
         # Check conflict with abort is validated
           dry_run: true
@@ -49,6 +52,7 @@ jobs:
           run_group_id: '123'
           environment_id: '1234'
           conflict: abort
+          pipeline_id: << pipeline.id >>
       - rf/run_qa:
         # Check conflict with abort-all is validated
           dry_run: true
@@ -56,6 +60,7 @@ jobs:
           run_group_id: '123'
           environment_id: '1234'
           conflict: abort-all
+          pipeline_id: << pipeline.id >>
 
 workflows:
   integration-tests_prod-release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,6 @@ jobs:
           dry_run: true
           token: 'TOP_SECRET_TOKEN'
           run_group_id: '123'
-          environment_id: '1234'
           conflict: abort
           pipeline_id: << pipeline.id >>
       - rf/run_qa:
@@ -58,7 +57,6 @@ jobs:
           dry_run: true
           token: 'TOP_SECRET_TOKEN'
           run_group_id: '123'
-          environment_id: '1234'
           conflict: abort-all
           pipeline_id: << pipeline.id >>
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ version: 2.1
 # If you don't have a top-level `orbs` section, add one
 orbs:
 # Add the Rainforest orb to that list
-  - rainforest: rainforest-qa/rainforest@1.3.1
+  - rainforest: rainforest-qa/rainforest@2.0.0
 
 # In your workflows, add it as a job to be run
 workflows:
@@ -233,7 +233,7 @@ This section describes the release process for the orb itself:
    orb
 1. If the `integration-tests_prod-release` workflow passes, get review and
    merge to master
-1. Create a [GitHub Release](https://github.com/rainforestapp/rainforest-orb/releases/new) with the proper `v`-prefixed version tag (i.e. `v1.3.1`). List **Bugfixes**, **Breaking changes**, and **New features** (if present), with links to the PRs. See [previous releases](https://github.com/rainforestapp/rainforest-orb/releases) for an idea of the format we've been using.
+1. Create a [GitHub Release](https://github.com/rainforestapp/rainforest-orb/releases/new) with the proper `v`-prefixed version tag (i.e. `v2.0.0`). List **Bugfixes**, **Breaking changes**, and **New features** (if present), with links to the PRs. See [previous releases](https://github.com/rainforestapp/rainforest-orb/releases) for an idea of the format we've been using.
 
 If you want to run an integration test against Rainforest, create a new branch
 in the Rainforest repo and update the `.circleci/config.yml` to use the dev

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ workflows:
       - rainforest/run:
           # Replace the value with the ID of whichever run group you want to run
           run_group_id: "123"
+          pipeline_id: << pipeline.id >>
 ```
 
 ## Optional Parameters
@@ -129,6 +130,18 @@ Any executor which has the Rainforest CLI installed will work.
 #### Default behavior
 A Docker image with the latest version of the Rainforest CLI installed will be used.
 
+## Rerunning failed tests
+To enable rerunning failed Rainforest tests when rerunning a failed Circle build, all you need to do is pass in the [pipeline ID](https://circleci.com/docs/2.0/configuration-reference/#using-pipeline-values) (`<< pipeline.id >>`) as the `pipeline_id` parameter to the `rainforest/run` job. Alternatively, if you are using the `rainforest/run_qa` command, you'll need to add the `rainforest/save_run_id` command in an ensuing step, passing in the same `pipeline_id` parameter.
+
+\ | Rerun from failed | Rerun from start
+--- | --- | ---
+Rainforest run failed | reruns failed tests | reruns failed tests
+Rainforest run passed | N/A | reruns failed tests
+
+If you want to always run the full Rainforest run, pass in a unique value to `pipeline_id`, for example, `"${CIRCLE_BUILD_NUM}"`.
+
+If you want to run the full Rainforest run for a single failed build, then you will need to kick off a new pipeline.
+
 ## Commands
 ### `install`
 Install the Rainforest CLI
@@ -155,6 +168,15 @@ Parameter | Type | Required | Allowed values | Default
 `release` | `string` | | any string | `"$CIRCLE_SHA1"`
 `token` | `env_var_name` | | any environment variable name | `"RAINFOREST_TOKEN"`
 `dry_run` | `boolean` | | `true` `false` | `false`
+`pipeline_id` | `string` | ✓ | any string | -
+
+### `save_run_id`
+Save the created run ID to the CircleCI cache
+#### Parameters
+Parameter | Type | Required | Allowed values | Default
+ --- | --- | --- | --- | --- |
+`pipeline_id` | `string` | ✓ | any string | -
+`when` | `enum` | | `always` `on_success` `on_fail`
 
 ## Executors
 ### `default`
@@ -179,6 +201,7 @@ workflows:
           release: $CIRCLE_TAG
           token: RAINFOREST_QA_API_TOKEN
           executor: my_custom_rainforest_executor
+          pipeline_id: << pipeline.id >>
 ```
 
 ### Running only on one branch
@@ -193,6 +216,7 @@ workflows:
               only:
                 - master
           run_group_id: "123"
+          pipeline_id: << pipeline.id >>
 ```
 
 ## Orb Release Process

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-VERSION = Gem::Version.new('1.3.1')
+VERSION = Gem::Version.new('2.0.0')
 
 def components
   # changes [1, 3] to [1, 3, 0]

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-VERSION = Gem::Version.new('1.3.0')
+VERSION = Gem::Version.new('1.3.1')
 
 def components
   # changes [1, 3] to [1, 3, 0]
@@ -10,7 +10,7 @@ end
 def update(*version)
   old_version = VERSION.version
   new_version = version.map(&:to_s).join('.')
-  `git grep -z -l -F #{old_version} | xargs -0 sed -i -e 's/#{old_version}/#{new_version}/g'`
+  `git grep -z -l -F #{old_version} | xargs -0 ruby -pi -e "gsub(/#{old_version}/, '#{new_version}')"`
 end
 
 namespace :update do

--- a/src/commands/run_qa.yml
+++ b/src/commands/run_qa.yml
@@ -122,7 +122,10 @@ steps:
             --release "<< parameters.release >>" \
             --junit-file ~/results/rainforest/results.xml
         fi
-  - store_test_results:
-      path: ~/results
-  - store_artifacts:
-      path: ~/results
+  - unless:
+      condition: << parameters.dry_run >>
+      steps:
+        - store_test_results:
+            path: ~/results
+        - store_artifacts:
+            path: ~/results

--- a/src/commands/run_qa.yml
+++ b/src/commands/run_qa.yml
@@ -40,6 +40,10 @@ parameters:
     type: boolean
     default: false
 
+  pipeline_id:
+    description: The CircleCI Pipeline ID ( << pipeline.id >> ), used to rerun only failed tests when a CircleCI workflow is rerun
+    type: string
+
 steps:
   - run:
       name: Run Rainforest
@@ -58,6 +62,31 @@ steps:
           exit 1
         fi
 
+        # Validate conflict
+        if [ -n "<< parameters.conflict >>" ] ; then
+          if ! echo "abort abort-all" | grep -Eq "\b"<< parameters.conflict >>"\b" ; then
+            echo "Error: << parameters.conflict >> not in (abort abort-all)"
+            exit 1
+          fi
+        fi
+
+        # Check for rerun
+        if [ -n "<< parameters.pipeline_id >>" ] && [ -f ~/pipeline/<< parameters.pipeline_id >> ] ; then
+          export RAINFOREST_RUN_ID=$(cat ~/pipeline/<< parameters.pipeline_id >>)
+          echo "Rerunning Run ${RAINFOREST_RUN_ID}"
+
+          if ! << parameters.dry_run >> ; then
+            # Create the rerun
+            rainforest-cli rerun \
+              --skip-update \
+              --token "${<< parameters.token >>}" \
+              <<# parameters.conflict >> --conflict "<< parameters.conflict >>" <</ parameters.conflict >> \
+              --junit-file ~/results/rainforest/results.xml
+          fi
+
+          exit 0
+        fi
+
         # Validate run_group_id
         if ! echo "<< parameters.run_group_id >>" | grep -Eq '^[0-9]+$' ; then
           echo "Error: run_group_id not a positive integer (<< parameters.run_group_id >>)"
@@ -68,14 +97,6 @@ steps:
         if [ -n "<< parameters.environment_id >>" ] ; then
           if ! echo "<< parameters.environment_id >>" | grep -Eq '^[0-9]+$' ; then
             echo "Error: environment_id not a positive integer (<< parameters.environment_id >>)"
-            exit 1
-          fi
-        fi
-
-        # Validate conflict
-        if [ -n "<< parameters.conflict >>" ] ; then
-          if ! echo "abort abort-all" | grep -Eq "\b"<< parameters.conflict >>"\b" ; then
-            echo "Error: << parameters.conflict >> not in (abort abort-all)"
             exit 1
           fi
         fi

--- a/src/commands/run_qa.yml
+++ b/src/commands/run_qa.yml
@@ -48,7 +48,7 @@ steps:
   - run:
       name: Run Rainforest
       environment:
-        ORB_VERSION: 1.3.1
+        ORB_VERSION: 2.0.0
       command: |
         # Show Orb Version
         echo "Using Rainforest Orb v${ORB_VERSION}"

--- a/src/commands/save_run_id.yml
+++ b/src/commands/save_run_id.yml
@@ -1,0 +1,24 @@
+description: Save Pipeline and RF Run ID
+
+parameters:
+  pipeline_id:
+    description: The CircleCI Pipeline ID ( << pipeline.id >> ), used to rerun only failed tests when a CircleCI workflow is rerun
+    type: string
+
+  when:
+    description: When to run the steps in this command (always, on_success, or on_fail). Default is on_fail
+    type: enum
+    enum: ["always", "on_fail", "on_success"]
+    default: on_fail
+
+steps:
+  - run:
+      name: Install xmllint
+      command: apk add libxml2-utils
+      when: << parameters.when >>
+  - run:
+      name: Save Pipeline and RF Run ID
+      command: |
+        mkdir ~/pipeline
+        xmllint --xpath "string(testsuite/@id)" ~/results/rainforest/results.xml > ~/pipeline/<< parameters.pipeline_id >>
+      when: << parameters.when >>

--- a/src/examples/simple.yml
+++ b/src/examples/simple.yml
@@ -3,7 +3,7 @@ description: Run tests from a specific run group
 usage:
   version: 2.1
   orbs:
-    rainforest: rainforest-qa/rainforest@1.3.1
+    rainforest: rainforest-qa/rainforest@2.0.0
   workflows:
     build:
       jobs:

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -40,6 +40,10 @@ parameters:
     type: boolean
     default: false
 
+  pipeline_id:
+    description: The CircleCI Pipeline ID ( << pipeline.id >> ), used to rerun only failed tests when a CircleCI workflow is rerun
+    type: string
+
   executor:
     description: The executor to run this command in
     type: executor
@@ -48,6 +52,10 @@ parameters:
 executor: <<parameters.executor>>
 
 steps:
+  - restore_cache:
+      keys:
+        - rainforest-run-{{ .Revision }}-{{ .BuildNum }}
+        - rainforest-run-{{ .Revision }}-
   - run_qa:
       description: << parameters.description >>
       run_group_id: << parameters.run_group_id >>
@@ -57,3 +65,11 @@ steps:
       release: << parameters.release >>
       token: << parameters.token >>
       dry_run: << parameters.dry_run >>
+      pipeline_id: << parameters.pipeline_id >>
+  - save_run_id:
+      pipeline_id: << parameters.pipeline_id >>
+  - save_cache:
+      when: on_fail
+      key: rainforest-run-{{ .Revision }}-{{ .BuildNum }}
+      paths:
+        - ~/pipeline


### PR DESCRIPTION
This bumps the version to `2.0.0` as it's a breaking change: there's a new `pipeline_id` required parameter. 