### PR TITLE
[RF-18783] Handle case where run errors rather than fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ version: 2.1
 # If you don't have a top-level `orbs` section, add one
 orbs:
 # Add the Rainforest orb to that list
-  - rainforest: rainforest-qa/rainforest@2.0.0
+  - rainforest: rainforest-qa/rainforest@2.0.1
 
 # In your workflows, add it as a job to be run
 workflows:
@@ -233,7 +233,7 @@ This section describes the release process for the orb itself:
    orb
 1. If the `integration-tests_prod-release` workflow passes, get review and
    merge to master
-1. Create a [GitHub Release](https://github.com/rainforestapp/rainforest-orb/releases/new) with the proper `v`-prefixed version tag (i.e. `v2.0.0`). List **Bugfixes**, **Breaking changes**, and **New features** (if present), with links to the PRs. See [previous releases](https://github.com/rainforestapp/rainforest-orb/releases) for an idea of the format we've been using.
+1. Create a [GitHub Release](https://github.com/rainforestapp/rainforest-orb/releases/new) with the proper `v`-prefixed version tag (i.e. `v2.0.1`). List **Bugfixes**, **Breaking changes**, and **New features** (if present), with links to the PRs. See [previous releases](https://github.com/rainforestapp/rainforest-orb/releases) for an idea of the format we've been using.
 
 If you want to run an integration test against Rainforest, create a new branch
 in the Rainforest repo and update the `.circleci/config.yml` to use the dev

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-VERSION = Gem::Version.new('2.0.0')
+VERSION = Gem::Version.new('2.0.1')
 
 def components
   # changes [1, 3] to [1, 3, 0]

--- a/src/commands/run_qa.yml
+++ b/src/commands/run_qa.yml
@@ -71,7 +71,7 @@ steps:
         fi
 
         # Check for rerun
-        if [ -n "<< parameters.pipeline_id >>" ] && [ -f ~/pipeline/<< parameters.pipeline_id >> ] ; then
+        if [ -n "<< parameters.pipeline_id >>" ] && [ -s ~/pipeline/<< parameters.pipeline_id >> ] ; then
           export RAINFOREST_RUN_ID=$(cat ~/pipeline/<< parameters.pipeline_id >>)
           echo "Rerunning Run ${RAINFOREST_RUN_ID}"
 

--- a/src/commands/run_qa.yml
+++ b/src/commands/run_qa.yml
@@ -48,7 +48,7 @@ steps:
   - run:
       name: Run Rainforest
       environment:
-        ORB_VERSION: 2.0.0
+        ORB_VERSION: 2.0.1
       command: |
         # Show Orb Version
         echo "Using Rainforest Orb v${ORB_VERSION}"

--- a/src/commands/save_run_id.yml
+++ b/src/commands/save_run_id.yml
@@ -19,6 +19,6 @@ steps:
   - run:
       name: Save Pipeline and RF Run ID
       command: |
-        mkdir ~/pipeline
+        mkdir -p ~/pipeline
         xmllint --xpath "string(testsuite/@id)" ~/results/rainforest/results.xml > ~/pipeline/<< parameters.pipeline_id >>
       when: << parameters.when >>

--- a/src/commands/save_run_id.yml
+++ b/src/commands/save_run_id.yml
@@ -20,5 +20,11 @@ steps:
       name: Save Pipeline and RF Run ID
       command: |
         mkdir -p ~/pipeline
-        xmllint --xpath "string(testsuite/@id)" ~/results/rainforest/results.xml > ~/pipeline/<< parameters.pipeline_id >>
+        RESULTS_FILE=~/results/rainforest/results.xml
+        PIPELINE_FILE=~/pipeline/<< parameters.pipeline_id >>
+        if [ -f ${RESULTS_FILE} ] ; then
+          xmllint --xpath "string(testsuite/@id)" ${RESULTS_FILE} > ${PIPELINE_FILE}
+        else
+          > ${PIPELINE_FILE}
+        fi
       when: << parameters.when >>

--- a/src/examples/simple.yml
+++ b/src/examples/simple.yml
@@ -3,7 +3,7 @@ description: Run tests from a specific run group
 usage:
   version: 2.1
   orbs:
-    rainforest: rainforest-qa/rainforest@2.0.0
+    rainforest: rainforest-qa/rainforest@2.0.1
   workflows:
     build:
       jobs:


### PR DESCRIPTION
When a run errors (_not_ when it fails), the build fails without a `results.xml` file for `save_run_id` to parse, which causes that step to fail as well.

Additionally, `run_qa` was only checking to see if the cached pipeline file existed, _not_ whether it contained any day, before trying a rerun, which would also cause that to fail.