### PR TITLE
Add support for the background flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ version: 2.1
 # If you don't have a top-level `orbs` section, add one
 orbs:
 # Add the Rainforest orb to that list
-  - rainforest: rainforest-qa/rainforest@2.0.1
+  - rainforest: rainforest-qa/rainforest@2.1.0
 
 # In your workflows, add it as a job to be run
 workflows:
@@ -233,6 +233,6 @@ This section describes the release process for the orb itself:
 1. Push the feature branch to Github to kick off the `lint-pack_validate_publish-dev` workflow in CircleCI.
 1. When the `lint-pack_validate_publish-dev` workflow completes successfully, it will trigger the `integration-tests_prod-release` workflow to test the orb.
 1. If the `integration-tests_prod-release` workflow passes, get review and merge to master.
-1. Create a [GitHub Release](https://github.com/rainforestapp/rainforest-orb/releases/new) with the proper `v`-prefixed version tag (i.e. `v2.0.1`). List **Bugfixes**, **Breaking changes**, and **New features** (if present), with links to the PRs. See [previous releases](https://github.com/rainforestapp/rainforest-orb/releases) for an idea of the format we've been using.
+1. Create a [GitHub Release](https://github.com/rainforestapp/rainforest-orb/releases/new) with the proper `v`-prefixed version tag (i.e. `v2.1.0`). List **Bugfixes**, **Breaking changes**, and **New features** (if present), with links to the PRs. See [previous releases](https://github.com/rainforestapp/rainforest-orb/releases) for an idea of the format we've been using.
 
 If you want to run an integration test against Rainforest, create a new branch in the Rainforest repo and update the `.circleci/config.yml` to use the dev version of the orb and add a job to kick-off a Rainforest run.

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-VERSION = Gem::Version.new('2.0.1')
+VERSION = Gem::Version.new('2.1.0')
 
 def components
   # changes [1, 3] to [1, 3, 0]

--- a/src/commands/run_qa.yml
+++ b/src/commands/run_qa.yml
@@ -40,6 +40,11 @@ parameters:
     type: boolean
     default: false
 
+  background:
+    description: Do not wait for a run to complete before exiting
+    type: boolean
+    default: false
+
   pipeline_id:
     description: The CircleCI Pipeline ID ( << pipeline.id >> ), used to rerun only failed tests when a CircleCI workflow is rerun
     type: string
@@ -81,6 +86,7 @@ steps:
               --skip-update \
               --token "${<< parameters.token >>}" \
               <<# parameters.conflict >> --conflict "<< parameters.conflict >>" <</ parameters.conflict >> \
+              --background="<< parameters.background >>" \
               --junit-file ~/results/rainforest/results.xml
           fi
 
@@ -120,6 +126,7 @@ steps:
             <<# parameters.conflict >> --conflict "<< parameters.conflict >>" <</ parameters.conflict >> \
             <<# parameters.crowd >> --crowd "<< parameters.crowd >>" <</ parameters.crowd >> \
             --release "<< parameters.release >>" \
+            --background="<< parameters.background >>" \
             --junit-file ~/results/rainforest/results.xml
         fi
   - unless:

--- a/src/commands/run_qa.yml
+++ b/src/commands/run_qa.yml
@@ -53,7 +53,7 @@ steps:
   - run:
       name: Run Rainforest
       environment:
-        ORB_VERSION: 2.0.1
+        ORB_VERSION: 2.1.0
       command: |
         # Show Orb Version
         echo "Using Rainforest Orb v${ORB_VERSION}"

--- a/src/examples/simple.yml
+++ b/src/examples/simple.yml
@@ -3,7 +3,7 @@ description: Run tests from a specific run group
 usage:
   version: 2.1
   orbs:
-    rainforest: rainforest-qa/rainforest@2.0.1
+    rainforest: rainforest-qa/rainforest@2.1.0
   workflows:
     build:
       jobs:

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -40,6 +40,11 @@ parameters:
     type: boolean
     default: false
 
+  background:
+    description: Do not wait for a rainforest run to complete before exiting
+    type: boolean
+    default: false
+
   pipeline_id:
     description: The CircleCI Pipeline ID ( << pipeline.id >> ), used to rerun only failed tests when a CircleCI workflow is rerun
     type: string
@@ -66,6 +71,7 @@ steps:
       token: << parameters.token >>
       dry_run: << parameters.dry_run >>
       pipeline_id: << parameters.pipeline_id >>
+      background: << parameters.background >>
   - save_run_id:
       pipeline_id: << parameters.pipeline_id >>
   - save_cache:


### PR DESCRIPTION
Let us kickoff scheduled runs from Circle without waiting for the
results. When we start scheduled runs we normally don't care about
whether the run is successful or not, so waiting for the result just
uses CircleCI credits.
