### PR TITLE
Don't let builds error when we haven't pushed in 90 days, update README accordingly.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 
 parameters:
   dev-orb-version:
-    default: 'dev:alpha'
+    default: '2'
     type: string
   run-integration-tests:
     default: false

--- a/README.md
+++ b/README.md
@@ -228,20 +228,11 @@ workflows:
 
 ## Orb Release Process
 This section describes the release process for the orb itself:
-1. Create a feature branch and do your work
-1. Update the version in the repo (i.e. `rake update:<major|minor|patch>`)
-1. Push the feature branch to Github to kick off the
-   `lint-pack_validate_publish-dev` workflow in CircleCI. This may fail in
-   CircleCI with the error "Cannot find rainforest-qa/rainforest@dev:dev:alpha
-   in the orb registry". Fix this by running `circleci orb publish src/@orb.yml
-   rainforest-qa/rainforest@dev:alpha` and rerun the build
-1. When the `lint-pack_validate_publish-dev` workflow completes successfully,
-   it will trigger the `integration-tests_prod-release` workflow to test the
-   orb
-1. If the `integration-tests_prod-release` workflow passes, get review and
-   merge to master
+1. Create a feature branch and do your work.
+1. Update the version in the repo (i.e. `rake update:<major|minor|patch>`).
+1. Push the feature branch to Github to kick off the `lint-pack_validate_publish-dev` workflow in CircleCI.
+1. When the `lint-pack_validate_publish-dev` workflow completes successfully, it will trigger the `integration-tests_prod-release` workflow to test the orb.
+1. If the `integration-tests_prod-release` workflow passes, get review and merge to master.
 1. Create a [GitHub Release](https://github.com/rainforestapp/rainforest-orb/releases/new) with the proper `v`-prefixed version tag (i.e. `v2.0.1`). List **Bugfixes**, **Breaking changes**, and **New features** (if present), with links to the PRs. See [previous releases](https://github.com/rainforestapp/rainforest-orb/releases) for an idea of the format we've been using.
 
-If you want to run an integration test against Rainforest, create a new branch
-in the Rainforest repo and update the `.circleci/config.yml` to use the dev
-version of the orb and add a job to kick-off a Rainforest run.
+If you want to run an integration test against Rainforest, create a new branch in the Rainforest repo and update the `.circleci/config.yml` to use the dev version of the orb and add a job to kick-off a Rainforest run.


### PR DESCRIPTION
This fixes the following issue:
```
#!/bin/sh -eo pipefail
# The dev version of rainforest-qa/rainforest@dev:alpha has expired. Dev versions of orbs are only valid for 90 days after publishing.
# 
# -------
# Warning: This configuration was auto-generated to show you the message above.
# Don't rerun this job. Rerunning will have no effect.
false

Exited with code exit status 1
CircleCI received exit code 1
```
https://app.circleci.com/pipelines/github/rainforestapp/rainforest-orb/232/workflows/686948a4-e7b5-4c45-b0c7-8131abe1ec8c/jobs/512

We don't need the rainforest orb for the first workflow (which is the only one that's kicked off with the default value for `dev-orb-version`), so we just need to use any value that won't expire.