### PR TITLE
[RF-22136] Rewrite `install` command to use GitHub releases rather than Equinox

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 
 parameters:
   dev-orb-version:
-    default: '2'
+    default: '3'
     type: string
   run-integration-tests:
     default: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,13 +19,24 @@ jobs:
       TOP_SECRET_TOKEN: 'MY_SECRET_PASSWORD'
       TOP_SECRET_TOKEN_WITH_SPACES: 'MY SECRET PASSWORD'
     steps:
+      - run: apk add curl jq wget
+      - rf/install:
+          architecture: "386"
+          version: v2.19.1
+      - run:
+          name: Is the CLI present, is it at the requested version
+          command: |
+            /usr/local/bin/rainforest-cli --skip-update --version | tee /tmp/rf-version
+            grep '2.19.1' /tmp/rf-version
       - rf/install:
           architecture: "386"
       - run:
-          name: Is the CLI present, is it from the stable channel
+          name: Is the CLI present, is it at the latest version
           command: |
-            /usr/local/bin/rainforest-cli --skip-update --version | tee /tmp/rf-version
-            grep 'stable channel' /tmp/rf-version
+            /usr/local/bin/rainforest-cli  --skip-update --version | tee /tmp/rf-version
+            /usr/local/bin/rainforest-cli update
+            /usr/local/bin/rainforest-cli  --skip-update --version | tee /tmp/rf-updated-version
+            diff /tmp/rf-version /tmp/rf-updated-version
       - rf/run_qa:
         # Check run group validation
           dry_run: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 
 parameters:
   dev-orb-version:
-    default: '3'
+    default: dev:alpha
     type: string
   run-integration-tests:
     default: false

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ version: 2.1
 # If you don't have a top-level `orbs` section, add one
 orbs:
 # Add the Rainforest orb to that list
-  - rainforest: rainforest-qa/rainforest@2.1.0
+  - rainforest: rainforest-qa/rainforest@3.0.0
 
 # In your workflows, add it as a job to be run
 workflows:
@@ -238,6 +238,6 @@ This section describes the release process for the orb itself:
 1. Push the feature branch to Github to kick off the `lint-pack_validate_publish-dev` workflow in CircleCI.
 1. When the `lint-pack_validate_publish-dev` workflow completes successfully, it will trigger the `integration-tests_prod-release` workflow to test the orb.
 1. If the `integration-tests_prod-release` workflow passes, get review and merge to master.
-1. Create a [GitHub Release](https://github.com/rainforestapp/rainforest-orb/releases/new) with the proper `v`-prefixed version tag (i.e. `v2.1.0`). List **Bugfixes**, **Breaking changes**, and **New features** (if present), with links to the PRs. See [previous releases](https://github.com/rainforestapp/rainforest-orb/releases) for an idea of the format we've been using.
+1. Create a [GitHub Release](https://github.com/rainforestapp/rainforest-orb/releases/new) with the proper `v`-prefixed version tag (i.e. `v3.0.0`). List **Bugfixes**, **Breaking changes**, and **New features** (if present), with links to the PRs. See [previous releases](https://github.com/rainforestapp/rainforest-orb/releases) for an idea of the format we've been using.
 
 If you want to run an integration test against Rainforest, create a new branch in the Rainforest repo and update the `.circleci/config.yml` to use the dev version of the orb and add a job to kick-off a Rainforest run.

--- a/README.md
+++ b/README.md
@@ -152,13 +152,18 @@ If you want to run the full Rainforest run for a single failed build, then you w
 ## Commands
 ### `install`
 Install the Rainforest CLI
+
+#### Requirements
+This command requires you to have [`jq`](https://stedolan.github.io/jq/) installed.
 #### Parameters
 Parameter | Type | Allowed values | Default
  --- | --- | --- | ---
-`channel` | `enum` | `stable`, `beta`, `dev` | `stable`
+`version` | `string` | `vX.Y.Z`* | `""` (latest)
 `platform` | `enum` | `darwin` (MacOS), `linux` | `linux`
 `architecture` | `enum` | `386` (32-bit), `amd64` (64-bit) | `amd64`
 `install_path` | `string` | | `/usr/local/bin`
+
+&ast; You can find a list of releases [here](https://github.com/rainforestapp/rainforest-cli/releases). The version must be greater than or equal to `v2.19.1`. All prior versions to not have downloadable assets available to install.
 
 ### `run_qa`
 Start a new Rainforest run

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-VERSION = Gem::Version.new('2.1.0')
+VERSION = Gem::Version.new('3.0.0')
 
 def components
   # changes [1, 3] to [1, 3, 0]

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -4,6 +4,10 @@ parameters:
     description: Where to install the CLI.
     type: string
     default: /usr/local/bin
+  channel:
+    description: "[DEPRECATED] This parameter no longer has any effect and will be removed in a future version"
+    type: string
+    default: ""
   version:
     description: Which (v-prefixed) version of the CLI to install. Defaults to the latest.
     type: string
@@ -19,6 +23,15 @@ parameters:
     enum: ["386", "amd64"]
     default: amd64
 steps:
+  - run:
+      name: Warn about deprecations
+      command: |
+        if [ -n "<< parameters.channel >>" ]; then
+          echo "The 'channel' parameter is deprecated, please remove it from your configuration."
+          echo "If you'd like to use a specific version, use the new 'version' parameter instead."
+          echo "See https://github.com/rainforestapp/rainforest-orb/releases/tag/v3.0.0 for more info."
+          exit 1
+        fi
   - run:
       name: Download and set up executable
       command: |

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -4,11 +4,10 @@ parameters:
     description: Where to install the CLI.
     type: string
     default: /usr/local/bin
-  channel:
-    description: The version of the CLI to install.
-    type: enum
-    enum: ["stable", "beta", "dev"]
-    default: stable
+  version:
+    description: Which (v-prefixed) version of the CLI to install. Defaults to the latest.
+    type: string
+    default: ""
   platform:
     description: Which platform to install the CLI for.
     type: enum
@@ -21,20 +20,17 @@ parameters:
     default: amd64
 steps:
   - run:
-      name: Get download URL
+      name: Download and set up executable
       command: |
-        url="https://bin.equinox.io/c"
-        file="rainforest-cli"
-        case << parameters.channel >> in
-          stable) url="$url/htRtQZagtfg"; file="$file-stable";;
-          beta) url="$url/csTtrGrMBYr"; file="$file-beta";;
-          dev) url="$url/6dz6cwxHnZ8"; file="$file-dev";;
-          *) echo "Invalid channel << parameters.channel >>" 1>&2; exit 1;;
-        esac
+        release_url=https://api.github.com/repos/rainforestapp/rainforest-cli/releases
+        if [ -n "<< parameters.version >>" ]; then
+          release_url="$release_url/tags/<< parameters.version >>"
+        else
+          release_url="$release_url/latest"
+        fi
+        echo $release_url
 
-        file="$file-<< parameters.platform >>-<< parameters.architecture >>.tgz"
-        url="$url/$file"
+        asset_url=$(curl $release_url | jq -r '.assets[].browser_download_url' | grep << parameters.platform >>-<< parameters.architecture >>)
 
-        wget $url
-        tar xvf $file -C << parameters.install_path >>
-        mv << parameters.install_path >>/rainforest << parameters.install_path >>/rainforest-cli
+        wget $asset_url -O rainforest-cli.tgz
+        tar xvf rainforest-cli.tgz -C << parameters.install_path >>

--- a/src/commands/run_qa.yml
+++ b/src/commands/run_qa.yml
@@ -53,7 +53,7 @@ steps:
   - run:
       name: Run Rainforest
       environment:
-        ORB_VERSION: 2.1.0
+        ORB_VERSION: 3.0.0
       command: |
         # Show Orb Version
         echo "Using Rainforest Orb v${ORB_VERSION}"

--- a/src/examples/simple.yml
+++ b/src/examples/simple.yml
@@ -3,7 +3,7 @@ description: Run tests from a specific run group
 usage:
   version: 2.1
   orbs:
-    rainforest: rainforest-qa/rainforest@2.1.0
+    rainforest: rainforest-qa/rainforest@3.0.0
   workflows:
     build:
       jobs:


### PR DESCRIPTION
This caused breaking changes, hence the major version bump up to `3.0.0`.

Anyone using the `run` job will not have to update their config (since the CLI is already preinstalled in the default executor used by that job), but anyone using the `install` command, passing in a `channel` argument will need to edit their config since that argument no longer exists.