### PR TITLE
Fix custom_url parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,6 @@ This section describes the release process for the orb itself:
 1. Push the feature branch to Github to kick off the `lint-pack_validate_publish-dev` workflow in CircleCI.
 1. When the `lint-pack_validate_publish-dev` workflow completes successfully, it will trigger the `integration-tests_prod-release` workflow to test the orb.
 1. If the `integration-tests_prod-release` workflow passes, get review and merge to master.
-1. Create a [GitHub Release](https://github.com/rainforestapp/rainforest-orb/releases/new) with the proper `v`-prefixed version tag (i.e. `v3.1.0`). List **Bugfixes**, **Breaking changes**, and **New features** (if present), with links to the PRs. See [previous releases](https://github.com/rainforestapp/rainforest-orb/releases) for an idea of the format we've been using.
+1. Create a [GitHub Release](https://github.com/rainforestapp/rainforest-orb/releases/new) with the proper `v`-prefixed version tag (i.e. `v3.1.1`). List **Bugfixes**, **Breaking changes**, and **New features** (if present), with links to the PRs. See [previous releases](https://github.com/rainforestapp/rainforest-orb/releases) for an idea of the format we've been using.
 
 If you want to run an integration test against Rainforest, create a new branch in the Rainforest repo and update the `.circleci/config.yml` to use the dev version of the orb and add a job to kick-off a Rainforest run.

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-VERSION = Gem::Version.new('3.1.0')
+VERSION = Gem::Version.new('3.1.1')
 
 def components
   # changes [1, 3] to [1, 3, 0]

--- a/src/commands/run_qa.yml
+++ b/src/commands/run_qa.yml
@@ -58,7 +58,7 @@ steps:
   - run:
       name: Run Rainforest
       environment:
-        ORB_VERSION: 3.1.0
+        ORB_VERSION: 3.1.1
       command: |
         # Show Orb Version
         echo "Using Rainforest Orb v${ORB_VERSION}"

--- a/src/commands/run_qa.yml
+++ b/src/commands/run_qa.yml
@@ -107,7 +107,6 @@ steps:
 
         # Set custom_url, or validate and set environment_id
         if [ -z "${RAINFOREST_RUN_ID}" ] && [ -n "<< parameters.custom_url >>" ] ; then
-          RUN_COMMAND="${RUN_COMMAND} --custom-url \"<< parameters.custom_url >>\""
           if [ -n "<< parameters.environment_id >>" ] ; then
             echo "Warning: Environment ID ignored. You've set values for the mutually exclusive custom_url and environment_id parameters. Unset one of these to fix this warning."
           fi
@@ -133,6 +132,7 @@ steps:
             --token "${<< parameters.token >>}" \
             --description "<< parameters.description >>" \
             --run-group "<< parameters.run_group_id >>" \
+            <<# parameters.custom_url >> --custom-url "<< parameters.custom_url >>" <</ parameters.custom_url >> \
             <<# parameters.environment_id >> --environment-id "<< parameters.environment_id >>" <</ parameters.environment_id >> \
             <<# parameters.conflict >> --conflict "<< parameters.conflict >>" <</ parameters.conflict >> \
             <<# parameters.crowd >> --crowd "<< parameters.crowd >>" <</ parameters.crowd >> \


### PR DESCRIPTION
This was too hastily copy-pasted from the GitHub Action repo 🤦🏼 The `RUN_COMMAND` env var does not exist in this repo, we were setting an env var that was then completely unused to kick off the Rainforest run.

