### PR TITLE
Allow passing in a cache_key to run job

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,20 @@ A Docker image with the latest version of the Rainforest CLI installed will be u
 ## Rerunning failed tests
 The Rainforest Orb uses CircleCI's cache and pipeline concept to know when a build is being rerun. In order for the orb to know within which pipeline it is being executed, you must pass in the [pipeline ID](https://circleci.com/docs/2.0/configuration-reference/#using-pipeline-values) (`<< pipeline.id >>`) to the `pipeline_id` parameter (available on both the `run` job and `run_qa` command).
 
+## Starting multiple Rainforest runs in a single workflow
+If the same workflow calls the `run` job more than once, you will need to pass in the `cache_key` parameter to the extra call sites. This will ensure that the right run is rerun when rerunning the workflow.
+
+```yaml
+workflows:
+  your_workflow:
+    jobs:
+      - rainforest/run:
+        # ...
+      - rainforest/run:
+        # ...
+        cache_key: "rainforest-second-run-{{ .Revision }}-{{ .BuildNum }}"
+```
+
 ### Using the `run_qa` command
 When using the command, you will need to explicitly define some of the logic [taken care of for you by the job](src/jobs/run.yml):
 - restoring from CircleCI cache before the `run_qa` step

--- a/README.md
+++ b/README.md
@@ -260,6 +260,6 @@ This section describes the release process for the orb itself:
 1. Push the feature branch to Github to kick off the `lint-pack_validate_publish-dev` workflow in CircleCI.
 1. When the `lint-pack_validate_publish-dev` workflow completes successfully, it will trigger the `integration-tests_prod-release` workflow to test the orb.
 1. If the `integration-tests_prod-release` workflow passes, get review and merge to master.
-1. Create a [GitHub Release](https://github.com/rainforestapp/rainforest-orb/releases/new) with the proper `v`-prefixed version tag (i.e. `v3.2.0`). List **Bugfixes**, **Breaking changes**, and **New features** (if present), with links to the PRs. See [previous releases](https://github.com/rainforestapp/rainforest-orb/releases) for an idea of the format we've been using.
+1. Create a [GitHub Release](https://github.com/rainforestapp/rainforest-orb/releases/new) with the proper `v`-prefixed version tag (i.e. `v3.3.0`). List **Bugfixes**, **Breaking changes**, and **New features** (if present), with links to the PRs. See [previous releases](https://github.com/rainforestapp/rainforest-orb/releases) for an idea of the format we've been using.
 
 If you want to run an integration test against Rainforest, create a new branch in the Rainforest repo and update the `.circleci/config.yml` to use the dev version of the orb and add a job to kick-off a Rainforest run.

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-VERSION = Gem::Version.new('3.2.0')
+VERSION = Gem::Version.new('3.3.0')
 
 def components
   # changes [1, 3] to [1, 3, 0]

--- a/src/commands/run_qa.yml
+++ b/src/commands/run_qa.yml
@@ -58,7 +58,7 @@ steps:
   - run:
       name: Run Rainforest
       environment:
-        ORB_VERSION: 3.2.0
+        ORB_VERSION: 3.3.0
       command: |
         # Show Orb Version
         echo "Using Rainforest Orb v${ORB_VERSION}"

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -54,6 +54,11 @@ parameters:
     description: The CircleCI Pipeline ID ( << pipeline.id >> ), used to rerun only failed tests when a CircleCI workflow is rerun
     type: string
 
+  cache_key:
+    description: The cache key, used to store/restore a Rainforest Run ID
+    type: string
+    default: "rainforest-run-{{ .Revision }}-{{ .BuildNum }}"
+
   executor:
     description: The executor to run this command in
     type: executor
@@ -64,8 +69,7 @@ executor: <<parameters.executor>>
 steps:
   - restore_cache:
       keys:
-        - rainforest-run-{{ .Revision }}-{{ .BuildNum }}
-        - rainforest-run-{{ .Revision }}-
+        - << parameters.cache_key >>
   - run_qa:
       description: << parameters.description >>
       run_group_id: << parameters.run_group_id >>
@@ -82,6 +86,6 @@ steps:
       pipeline_id: << parameters.pipeline_id >>
   - save_cache:
       when: on_fail
-      key: rainforest-run-{{ .Revision }}-{{ .BuildNum }}
+      key: << parameters.cache_key >>
       paths:
         - ~/pipeline


### PR DESCRIPTION
This is useful for workflows calling `rainforest/run` multiple times. With the current version of the orb, the same cache key is reused, so the second job that gets triggered will attempt to rerun the run from the first job, rather than start its own run.

The default value for the parameter is the current version's hardcoded value, so this is a non-breaking change.