### PR TITLE
Add junit_path parameter to run job and run_qa command

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ A Docker image with the latest version of the Rainforest CLI installed will be u
 The Rainforest Orb uses CircleCI's cache and pipeline concept to know when a build is being rerun. In order for the orb to know within which pipeline it is being executed, you must pass in the [pipeline ID](https://circleci.com/docs/2.0/configuration-reference/#using-pipeline-values) (`<< pipeline.id >>`) to the `pipeline_id` parameter (available on both the `run` job and `run_qa` command).
 
 ## Starting multiple Rainforest runs in a single workflow
-If the same workflow calls the `run` job more than once, you will need to pass in the `cache_key` parameter to the extra call sites. This will ensure that the right run is rerun when rerunning the workflow.
+If the same workflow calls the `run` job more than once, you will need to pass in the `cache_key` and `junit_path` parameters to the extra call sites. This will ensure that all runs are properly triggered and that results for each run are stored separately.
 
 ```yaml
 workflows:
@@ -152,6 +152,7 @@ workflows:
       - rainforest/run:
         # ...
         cache_key: "rainforest-second-run-{{ .Revision }}-{{ .BuildNum }}"
+        junit_path: "rainforest_second_run"
 ```
 
 ### Using the `run_qa` command

--- a/README.md
+++ b/README.md
@@ -261,6 +261,6 @@ This section describes the release process for the orb itself:
 1. Push the feature branch to Github to kick off the `lint-pack_validate_publish-dev` workflow in CircleCI.
 1. When the `lint-pack_validate_publish-dev` workflow completes successfully, it will trigger the `integration-tests_prod-release` workflow to test the orb.
 1. If the `integration-tests_prod-release` workflow passes, get review and merge to master.
-1. Create a [GitHub Release](https://github.com/rainforestapp/rainforest-orb/releases/new) with the proper `v`-prefixed version tag (i.e. `v3.3.0`). List **Bugfixes**, **Breaking changes**, and **New features** (if present), with links to the PRs. See [previous releases](https://github.com/rainforestapp/rainforest-orb/releases) for an idea of the format we've been using.
+1. Create a [GitHub Release](https://github.com/rainforestapp/rainforest-orb/releases/new) with the proper `v`-prefixed version tag (i.e. `v3.3.1`). List **Bugfixes**, **Breaking changes**, and **New features** (if present), with links to the PRs. See [previous releases](https://github.com/rainforestapp/rainforest-orb/releases) for an idea of the format we've been using.
 
 If you want to run an integration test against Rainforest, create a new branch in the Rainforest repo and update the `.circleci/config.yml` to use the dev version of the orb and add a job to kick-off a Rainforest run.

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-VERSION = Gem::Version.new('3.3.0')
+VERSION = Gem::Version.new('3.3.1')
 
 def components
   # changes [1, 3] to [1, 3, 0]

--- a/src/commands/run_qa.yml
+++ b/src/commands/run_qa.yml
@@ -63,7 +63,7 @@ steps:
   - run:
       name: Run Rainforest
       environment:
-        ORB_VERSION: 3.3.0
+        ORB_VERSION: 3.3.1
       command: |
         # Show Orb Version
         echo "Using Rainforest Orb v${ORB_VERSION}"

--- a/src/commands/run_qa.yml
+++ b/src/commands/run_qa.yml
@@ -50,6 +50,11 @@ parameters:
     type: boolean
     default: false
 
+  junit_path:
+    description: Folder under ~/results to store the JUnit results.xml file
+    type: string
+    default: "rainforest"
+
   pipeline_id:
     description: The CircleCI Pipeline ID ( << pipeline.id >> ), used to rerun only failed tests when a CircleCI workflow is rerun
     type: string
@@ -64,7 +69,7 @@ steps:
         echo "Using Rainforest Orb v${ORB_VERSION}"
 
         # Ensure results directory is there
-        mkdir -p ~/results/rainforest
+        mkdir -p ~/results/<< parameters.junit_path >>
 
         # Validate token
         if [ -z "${<< parameters.token >>}" ] ; then
@@ -92,7 +97,7 @@ steps:
               --token "${<< parameters.token >>}" \
               <<# parameters.conflict >> --conflict "<< parameters.conflict >>" <</ parameters.conflict >> \
               --background="<< parameters.background >>" \
-              --junit-file ~/results/rainforest/results.xml \
+              --junit-file ~/results/<< parameters.junit_path >>/results.xml \
               --save-run-id ~/.rainforest_run_id
           fi
 
@@ -138,7 +143,7 @@ steps:
             <<# parameters.crowd >> --crowd "<< parameters.crowd >>" <</ parameters.crowd >> \
             --release "<< parameters.release >>" \
             --background="<< parameters.background >>" \
-            --junit-file ~/results/rainforest/results.xml \
+            --junit-file ~/results/<< parameters.junit_path >>/results.xml \
             --save-run-id ~/.rainforest_run_id
         fi
   - unless:

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -50,6 +50,11 @@ parameters:
     type: boolean
     default: false
 
+  junit_path:
+    description: Folder under ~/results to store the JUnit results.xml file
+    type: string
+    default: "~/results/rainforest"
+
   pipeline_id:
     description: The CircleCI Pipeline ID ( << pipeline.id >> ), used to rerun only failed tests when a CircleCI workflow is rerun
     type: string
@@ -80,6 +85,7 @@ steps:
       release: << parameters.release >>
       token: << parameters.token >>
       dry_run: << parameters.dry_run >>
+      junit_path: << parameters.junit_path >>
       pipeline_id: << parameters.pipeline_id >>
       background: << parameters.background >>
   - save_run_id:


### PR DESCRIPTION
Much like #42 enabled triggering multiple runs in a single workflow, this PR will allow for properly storing results for separate runs in separate JUnit files.