### PR TITLE
Add support for `automation_max_retries`, remove deprecated `crowd`, change default `token` env var name

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,6 @@ This section describes the release process for the orb itself:
 1. Push the feature branch to Github to kick off the `lint-pack_validate_publish-dev` workflow in CircleCI.
 1. When the `lint-pack_validate_publish-dev` workflow completes successfully, it will trigger the `integration-tests_prod-release` workflow to test the orb.
 1. If the `integration-tests_prod-release` workflow passes, get review and merge to master.
-1. Create a [GitHub Release](https://github.com/rainforestapp/rainforest-orb/releases/new) with the proper `v`-prefixed version tag (i.e. `v4.1.0`). List **Bugfixes**, **Breaking changes**, and **New features** (if present), with links to the PRs. See [previous releases](https://github.com/rainforestapp/rainforest-orb/releases) for an idea of the format we've been using.
+1. Create a [GitHub Release](https://github.com/rainforestapp/rainforest-orb/releases/new) with the proper `v`-prefixed version tag (i.e. `v5.0.0`). List **Bugfixes**, **Breaking changes**, and **New features** (if present), with links to the PRs. See [previous releases](https://github.com/rainforestapp/rainforest-orb/releases) for an idea of the format we've been using.
 
 If you want to run an integration test against Rainforest, create a new branch in the Rainforest repo and update the `.circleci/config.yml` to use the dev version of the orb and add a job to kick-off a Rainforest run.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,13 @@ A string used to link a run to a release (for example, a `git` SHA or tag, a ver
 #### Default behavior
 If no `release` parameter is passed in, the SHA1 hash of the latest commit of the current build (obtained via the `CIRCLE_SHA1` environment variable) will be used.
 
+### `automation_max_retries`
+If set to a value > 0 and a test run using automation fails, it will be retried within the same run, up to that number of times.
+#### Type
+`string`
+#### Default behavior
+If no `automation_max_retries` parameter is passed in, the created run will use the Run Group's configured `automation_max_retries` setting.
+
 ### `token`
 This is not your Rainforest API token, but the name of the environment variable in which it is stored.
 #### Type
@@ -201,6 +208,7 @@ Parameter | Type | Required | Allowed values | Default
 `conflict` | `string` | | `cancel` `cancel-all` | `""`
 `execution_method` | `string` | | `automation` `crowd` `automation_and_crowd` `on_premise` | `""`
 `release` | `string` | | any string | `"$CIRCLE_SHA1"`
+`automation_max_retries` | `string` | | string evaluating to a positive integer | `""`
 `token` | `env_var_name` | | any environment variable name | `"RAINFOREST_TOKEN"`
 `dry_run` | `boolean` | | `true` `false` | `false`
 `pipeline_id` | `string` | ✓ | any string | —

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If you don't already have one, you can sign up for a free account [here](https:/
 ### A Rainforest QA API token
 
 You can find yours on the [Integrations](https://app.rainforestqa.com/settings/integrations) setting page.
-Do not expose this token in your `circleci/.config.yml` file. Instead, [use an environment variable in CircleCI](https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project). The default name for this token is `RAINFOREST_TOKEN`. You may use a different name, and pass that in to the `rainforest/run` command (see below).
+Do not expose this token in your `circleci/.config.yml` file. Instead, [use an environment variable in CircleCI](https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project). The default name for this variable is `RAINFOREST_API_TOKEN`. You may use a different name, and pass that in to the `rainforest/run` command (see below).
 
 ### A run group with at least one test
 
@@ -125,7 +125,7 @@ This is not your Rainforest API token, but the name of the environment variable 
 #### Type
 `env_var_name`
 #### Default behavior
-If no `token` parameter is passed in, the `RAINFOREST_TOKEN` environment variable is assumed to contain your Rainforest QA API token.
+If no `token` parameter is passed in, the `RAINFOREST_API_TOKEN` environment variable is assumed to contain your Rainforest QA API token.
 
 ### `dry_run`
 Set to `true` to run parameter validations without actually starting a run in Rainforest.
@@ -209,7 +209,7 @@ Parameter | Type | Required | Allowed values | Default
 `execution_method` | `string` | | `automation` `crowd` `automation_and_crowd` `on_premise` | `""`
 `release` | `string` | | any string | `"$CIRCLE_SHA1"`
 `automation_max_retries` | `string` | | string evaluating to a positive integer | `""`
-`token` | `env_var_name` | | any environment variable name | `"RAINFOREST_TOKEN"`
+`token` | `env_var_name` | | any environment variable name | `"RAINFOREST_API_TOKEN"`
 `dry_run` | `boolean` | | `true` `false` | `false`
 `pipeline_id` | `string` | ✓ | any string | —
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-VERSION = Gem::Version.new('4.1.0')
+VERSION = Gem::Version.new('5.0.0')
 
 def components
   # changes [1, 3] to [1, 3, 0]

--- a/src/commands/run_qa.yml
+++ b/src/commands/run_qa.yml
@@ -30,11 +30,6 @@ parameters:
     type: string
     default: ""
 
-  crowd:
-    description: "DEPRECATED: Use `execution_method` instead"
-    type: string
-    default: ""
-
   release:
     description: Manually entered release information about the release the run is associated with
     type: string
@@ -132,22 +127,10 @@ steps:
           fi
         fi
 
-        # Validate execution_method / crowd
+        # Validate execution_method
         if [ -n "<< parameters.execution_method >>" ] ; then
           if ! echo "automation crowd automation_and_crowd on_premise" | grep -Eq "\b"<< parameters.execution_method >>"\b" ; then
             echo "Error: << parameters.execution_method >> not in (automation crowd automation_and_crowd on_premise)"
-            exit 1
-          fi
-        elif [ -n "<< parameters.crowd >>" ] ; then
-          echo "The 'crowd' parameter is deprecated, use 'execution_method' instead."
-
-          if [ -n "<< parameters.execution_method >>" ] ; then
-            echo "Error: execution_method and crowd are mutually exclusive"
-            exit 1
-          fi
-
-          if ! echo "default automation automation_and_crowd on_premise_crowd" | grep -Eq "\b"<< parameters.crowd >>"\b" ; then
-            echo "Error: << parameters.crowd >> not in (default automation automation_and_crowd on_premise_crowd)"
             exit 1
           fi
         fi
@@ -170,7 +153,6 @@ steps:
             <<# parameters.environment_id >> --environment-id "<< parameters.environment_id >>" <</ parameters.environment_id >> \
             <<# parameters.conflict >> --conflict "<< parameters.conflict >>" <</ parameters.conflict >> \
             <<# parameters.execution_method >> --execution-method "<< parameters.execution_method >>" <</ parameters.execution_method >> \
-            <<# parameters.crowd >> --crowd "<< parameters.crowd >>" <</ parameters.crowd >> \
             <<# parameters.automation_max_retries >> --automation-max-retries "<< parameters.automation_max_retries >>" <</ parameters.automation_max_retries >> \
             --release "<< parameters.release >>" \
             --background="<< parameters.background >>" \

--- a/src/commands/run_qa.yml
+++ b/src/commands/run_qa.yml
@@ -121,11 +121,11 @@ steps:
         fi
 
         # Set custom_url, or validate and set environment_id
-        if [ -z "${RAINFOREST_RUN_ID}" ] && [ -n "<< parameters.custom_url >>" ] ; then
+        if [ -n "<< parameters.custom_url >>" ] ; then
           if [ -n "<< parameters.environment_id >>" ] ; then
             echo "Warning: Environment ID ignored. You've set values for the mutually exclusive custom_url and environment_id parameters. Unset one of these to fix this warning."
           fi
-        elif [ -z "${RAINFOREST_RUN_ID}" ] && [ -n "<< parameters.environment_id >>" ] ; then
+        elif [ -n "<< parameters.environment_id >>" ] ; then
           if ! echo "<< parameters.environment_id >>" | grep -Eq '^[0-9]+$' ; then
             echo "Error: environment_id not a positive integer (<< parameters.environment_id >>)"
             exit 1

--- a/src/commands/run_qa.yml
+++ b/src/commands/run_qa.yml
@@ -68,7 +68,7 @@ steps:
   - run:
       name: Run Rainforest
       environment:
-        ORB_VERSION: 4.1.0
+        ORB_VERSION: 5.0.0
       command: |
         # Show Orb Version
         echo "Using Rainforest Orb v${ORB_VERSION}"

--- a/src/commands/run_qa.yml
+++ b/src/commands/run_qa.yml
@@ -40,6 +40,11 @@ parameters:
     type: string
     default: "$CIRCLE_SHA1"
 
+  automation_max_retries:
+    description: If set to a value > 0 and a test run using automation fails, it will be retried within the same run, up to that number of times
+    type: string
+    default: ""
+
   token:
     description: The name of the environment variable containing your Rainforest QA API token
     type: env_var_name
@@ -147,6 +152,13 @@ steps:
           fi
         fi
 
+        # Validate automation_max_retries
+        if [ -n "<< parameters.automation_max_retries >>" ] ; then
+          if ! echo "<< parameters.automation_max_retries >>" | grep -Eq '^[0-9]+$' ; then
+            error "automation_max_retries not a positive integer (<< parameters.automation_max_retries >>)"
+          fi
+        fi
+
         if ! << parameters.dry_run >> ; then
           # Create the run
           rainforest run \
@@ -159,6 +171,7 @@ steps:
             <<# parameters.conflict >> --conflict "<< parameters.conflict >>" <</ parameters.conflict >> \
             <<# parameters.execution_method >> --execution-method "<< parameters.execution_method >>" <</ parameters.execution_method >> \
             <<# parameters.crowd >> --crowd "<< parameters.crowd >>" <</ parameters.crowd >> \
+            <<# parameters.automation_max_retries >> --automation-max-retries "<< parameters.automation_max_retries >>" <</ parameters.automation_max_retries >> \
             --release "<< parameters.release >>" \
             --background="<< parameters.background >>" \
             --junit-file ~/results/<< parameters.junit_path >>/results.xml \

--- a/src/commands/run_qa.yml
+++ b/src/commands/run_qa.yml
@@ -43,7 +43,7 @@ parameters:
   token:
     description: The name of the environment variable containing your Rainforest QA API token
     type: env_var_name
-    default: RAINFOREST_TOKEN
+    default: RAINFOREST_API_TOKEN
 
   dry_run:
     description: Set to true to run parameter validations without starting a new Rainforest run

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -30,11 +30,6 @@ parameters:
     type: string
     default: ""
 
-  crowd:
-    description: "DEPRECATED: Use `execution_method` instead"
-    type: string
-    default: ""
-
   release:
     description: Manually entered release information about the release the run is associated with
     type: string
@@ -92,7 +87,6 @@ steps:
       custom_url: << parameters.custom_url >>
       conflict: << parameters.conflict >>
       execution_method: << parameters.execution_method >>
-      crowd: << parameters.crowd >>
       release: << parameters.release >>
       automation_max_retries: << parameters.automation_max_retries >>
       token: << parameters.token >>

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -43,7 +43,7 @@ parameters:
   token:
     description: The name of the environment variable containing your Rainforest QA API token
     type: env_var_name
-    default: RAINFOREST_TOKEN
+    default: RAINFOREST_API_TOKEN
 
   dry_run:
     description: Set to true to run parameter validations without starting a new Rainforest run

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -40,6 +40,11 @@ parameters:
     type: string
     default: "$CIRCLE_SHA1"
 
+  automation_max_retries:
+    description: If set to a value > 0 and a test run using automation fails, it will be retried within the same run, up to that number of times
+    type: string
+    default: ""
+
   token:
     description: The name of the environment variable containing your Rainforest QA API token
     type: env_var_name
@@ -89,6 +94,7 @@ steps:
       execution_method: << parameters.execution_method >>
       crowd: << parameters.crowd >>
       release: << parameters.release >>
+      automation_max_retries: << parameters.automation_max_retries >>
       token: << parameters.token >>
       dry_run: << parameters.dry_run >>
       junit_path: << parameters.junit_path >>


### PR DESCRIPTION
- Add an `automation_max_retries` parameter to `run` / `run_qa` to bring parity with the GitHub Action (see https://github.com/rainforestapp/github-action/pull/17)
- Remove `crowd`, deprecated in #46 
- Change the default value for the `token` parameter to `RAINFOREST_API_TOKEN`, to match the default used by the underlying CLI.

The latter two are breaking changes, hence the major version update to `5.0.0`.