### PR TITLE
[RF-25669] Support starting a run on a branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ If set to a value > 0 and a test run using automation fails, it will be retried 
 #### Default behavior
 If no `automation_max_retries` parameter is passed in, the created run will use the Run Group's configured `automation_max_retries` setting.
 
+### `branch`
+Use a specific Rainforest branch for this run.
+#### Type
+`string`
+#### Default behavior
+If no branch parameter is passed in, the main branch will be used.
+
 ### `token`
 This is not your Rainforest API token, but the name of the environment variable in which it is stored.
 #### Type
@@ -209,6 +216,7 @@ Parameter | Type | Required | Allowed values | Default
 `execution_method` | `string` | | `automation` `crowd` `automation_and_crowd` `on_premise` | `""`
 `release` | `string` | | any string | `"$CIRCLE_SHA1"`
 `automation_max_retries` | `string` | | string evaluating to a positive integer | `""`
+`branch` | `string` | | any string | `""`
 `token` | `env_var_name` | | any environment variable name | `"RAINFOREST_API_TOKEN"`
 `dry_run` | `boolean` | | `true` `false` | `false`
 `pipeline_id` | `string` | ✓ | any string | —

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-VERSION = Gem::Version.new('5.0.0')
+VERSION = Gem::Version.new('5.1.0')
 
 def components
   # changes [1, 3] to [1, 3, 0]

--- a/src/commands/run_qa.yml
+++ b/src/commands/run_qa.yml
@@ -73,7 +73,7 @@ steps:
   - run:
       name: Run Rainforest
       environment:
-        ORB_VERSION: 5.0.0
+        ORB_VERSION: 5.1.0
       command: |
         # Show Orb Version
         echo "Using Rainforest Orb v${ORB_VERSION}"

--- a/src/commands/run_qa.yml
+++ b/src/commands/run_qa.yml
@@ -40,6 +40,11 @@ parameters:
     type: string
     default: ""
 
+  branch:
+    description: Use a specific Rainforest branch for this run
+    type: string
+    default: ""
+
   token:
     description: The name of the environment variable containing your Rainforest QA API token
     type: env_var_name
@@ -154,6 +159,7 @@ steps:
             <<# parameters.conflict >> --conflict "<< parameters.conflict >>" <</ parameters.conflict >> \
             <<# parameters.execution_method >> --execution-method "<< parameters.execution_method >>" <</ parameters.execution_method >> \
             <<# parameters.automation_max_retries >> --automation-max-retries "<< parameters.automation_max_retries >>" <</ parameters.automation_max_retries >> \
+            <<# parameters.branch >> --branch "<< parameters.branch >>" <</ parameters.branch >> \
             --release "<< parameters.release >>" \
             --background="<< parameters.background >>" \
             --junit-file ~/results/<< parameters.junit_path >>/results.xml \

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -40,6 +40,11 @@ parameters:
     type: string
     default: ""
 
+  branch:
+    description: Use a specific Rainforest branch for this run
+    type: string
+    default: ""
+
   token:
     description: The name of the environment variable containing your Rainforest QA API token
     type: env_var_name
@@ -89,6 +94,7 @@ steps:
       execution_method: << parameters.execution_method >>
       release: << parameters.release >>
       automation_max_retries: << parameters.automation_max_retries >>
+      branch: << parameters.branch >>
       token: << parameters.token >>
       dry_run: << parameters.dry_run >>
       junit_path: << parameters.junit_path >>


### PR DESCRIPTION
Add support for a `branch` param which allows you specify which Rainforest branch should be used for the run.