### PR TITLE
RF-39420 Pass GitHub token to CLI install curl to avoid rate limiting.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-VERSION = Gem::Version.new('5.1.1')
+VERSION = Gem::Version.new('5.2.0')
 
 def components
   # changes [1, 3] to [1, 3, 0]

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -22,6 +22,10 @@ parameters:
     type: enum
     enum: ["386", "amd64"]
     default: amd64
+  github_token:
+    description: Name of the environment variable holding a GitHub token, used to avoid API rate limits when fetching the CLI release.
+    type: env_var_name
+    default: GITHUB_TOKEN
 steps:
   - run:
       name: Warn about deprecations
@@ -43,7 +47,18 @@ steps:
         fi
         echo $release_url
 
-        asset_url=$(curl $release_url | jq -r '.assets[].browser_download_url' | grep << parameters.platform >>-<< parameters.architecture >>)
+        # Pass a GitHub token if available to avoid unauthenticated rate limits
+        # (60 req/hr). Without a token, the API may return a rate-limit error
+        # with no .assets field, causing jq to fail and the install to silently
+        # succeed with an empty asset_url. -f makes curl exit non-zero on HTTP
+        # errors so the step fails loudly instead.
+        if [ -n "${<< parameters.github_token >>}" ]; then
+          api_response=$(curl -f -H "Authorization: token ${<< parameters.github_token >>}" "$release_url")
+        else
+          api_response=$(curl -f "$release_url")
+        fi
+
+        asset_url=$(echo "$api_response" | jq -r '.assets[].browser_download_url' | grep << parameters.platform >>-<< parameters.architecture >>)
 
         wget $asset_url -O rainforest-cli.tgz
         tar xvf rainforest-cli.tgz -C << parameters.install_path >>

--- a/src/commands/run_qa.yml
+++ b/src/commands/run_qa.yml
@@ -73,7 +73,7 @@ steps:
   - run:
       name: Run Rainforest
       environment:
-        ORB_VERSION: 5.1.1
+        ORB_VERSION: 5.2.1
       command: |
         # Show Orb Version
         echo "Using Rainforest Orb v${ORB_VERSION}"


### PR DESCRIPTION
Concern raised in: https://rainforest.slack.com/archives/C041YNBHGJH/p1771907038715099

When the GitHub API rate limit is hit, the unauthenticated curl request in the install command returns an error response with no .assets field, causing jq to fail and the CLI to never be installed. Downstream jobs then surface a misleading unrelated error that obscures the real cause.

@ubergeek42 I believe doing this, we'll also need to setup `GITHUB_TOKEN` in the project environment variables?
